### PR TITLE
Update GitHub repository references from docgen to docx_builder

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -246,7 +246,7 @@ main repo. When ready, they submit a PR.
 
 ```
 Control Sheet:
-  GitHub URL: https://raw.githubusercontent.com/YOURFORK/docgen/main/
+  GitHub URL: https://raw.githubusercontent.com/YOURFORK/docx_builder/main/
 ```
 
 ### Mechanism D: Local Development Server (Advanced)
@@ -301,7 +301,7 @@ The `github_loader.py` module handles fetching and caching from GitHub:
 
 import requests  # works in Pyodide
 
-GITHUB_BASE = "https://raw.githubusercontent.com/OWNER/docgen/main"
+GITHUB_BASE = "https://raw.githubusercontent.com/ccirone2/docx_builder/main"
 
 _cache = {}  # in-memory cache for the session
 
@@ -413,7 +413,7 @@ from xlwings import script
 import requests
 import yaml
 
-GITHUB_BASE = "https://raw.githubusercontent.com/OWNER/docgen/main"
+GITHUB_BASE = "https://raw.githubusercontent.com/ccirone2/docx_builder/main"
 
 
 def _fetch(path):
@@ -488,7 +488,7 @@ Control Sheet Layout:
 │  CONFIGURATION        │                 │                │
 │                       │                 │                │
 │  GitHub Repo URL:     │  https://raw.githubusercontent   │
-│                       │  .com/OWNER/docgen/main          │
+│                       │  .com/ccirone2/docx_builder/main          │
 │                       │                 │                │
 │  Custom Schemas:      │  (use file picker or paste YAML) │
 │                       │                 │                │

--- a/engine/github_loader.py
+++ b/engine/github_loader.py
@@ -26,7 +26,7 @@ import yaml
 # Default GitHub base URL. Users can override this on the Control sheet
 # to point at their fork or a different branch.
 DEFAULT_GITHUB_BASE = (
-    "https://raw.githubusercontent.com/OWNER/docgen/main"
+    "https://raw.githubusercontent.com/ccirone2/docx_builder/main"
 )
 
 # Paths within the repo


### PR DESCRIPTION
## Summary
This PR updates all GitHub repository URL references throughout the codebase to point to the correct repository name and owner. The references have been changed from the placeholder `OWNER/docgen` to the actual repository `ccirone2/docx_builder`.

## Key Changes
- Updated `DEFAULT_GITHUB_BASE` constant in `engine/github_loader.py` to use the correct GitHub repository URL
- Updated `GITHUB_BASE` constant in architecture documentation examples to reflect the actual repository
- Updated all documentation references in `ARCHITECTURE.md` including:
  - Control Sheet configuration example
  - Code examples showing the github_loader module usage
  - Code examples showing xlwings integration
  - Control Sheet layout diagram

## Details
These changes ensure that users following the documentation and code examples will correctly reference the actual `ccirone2/docx_builder` repository on GitHub rather than placeholder values. This is critical for the GitHub loader functionality to work properly when fetching resources from the correct repository.

https://claude.ai/code/session_01Hwc2Q1ykVDqP54upNy36f7