### PR TITLE
Refactor workbook bootstrap: loader/runner architecture + docs audit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,27 +30,25 @@ for contributions back to the repo.
 │  │   ├── data_exchange.py                                          │
 │  │   ├── doc_generator.py                                          │
 │  │   ├── excel_builder.py                                          │
-│  │   └── file_bridge.py                                            │
+│  │   ├── file_bridge.py                                            │
+│  │   ├── validation_ux.py                                          │
+│  │   └── log.py                                                    │
 │  │                                                                  │
 │  ├── schemas/             Official schema definitions               │
 │  │   ├── registry.yaml        ← master index of all schemas        │
 │  │   ├── rfq_electric_utility.yaml                                 │
-│  │   ├── change_order.yaml                                         │
-│  │   └── ...                                                       │
-│  │                                                                  │
-│  ├── templates/           Programmatic doc templates (Python)       │
-│  │   ├── rfq_electric_utility.py                                   │
-│  │   ├── change_order.py                                           │
-│  │   └── ...                                                       │
+│  │   └── ...                  (future: change_order, etc.)         │
 │  │                                                                  │
 │  ├── workbook/            Thin-shell workbook + setup instructions  │
-│  │   ├── DocGen.xlsx                                               │
+│  │   ├── loader.py            ← paste into xlwings Lite (stable)   │
+│  │   ├── runner.py            ← fetched at runtime from GitHub     │
+│  │   ├── scripts.py           ← self-contained alternative         │
 │  │   └── README.md                                                 │
 │  │                                                                  │
 │  └── docs/                User & contributor documentation          │
 │      ├── CONTRIBUTING.md                                           │
 │      ├── SCHEMA_AUTHORING.md                                       │
-│      └── TEMPLATE_AUTHORING.md                                     │
+│      └── USER_GUIDE.md                                             │
 │                                                                     │
 └─────────────────────┬───────────────────────────────────────────────┘
                       │
@@ -89,39 +87,41 @@ docgen/
 ├── engine/                             # Core Python engine
 │   ├── __init__.py
 │   ├── config.py                       # Settings, GitHub URLs, paths
+│   ├── log.py                          # Timestamped logging helpers
 │   ├── schema_loader.py                # Parse YAML → Schema objects
 │   ├── data_exchange.py                # Import/export YAML, LLM prompts
 │   ├── doc_generator.py                # Merge data → .docx in memory
 │   ├── excel_builder.py                # Build data entry sheets from schema
 │   ├── file_bridge.py                  # Pyodide → browser download
+│   ├── validation_ux.py                # Color-coded validation reports
 │   ├── template_registry.py            # Schema ↔ template mapping
 │   └── github_loader.py               # Fetch files from GitHub + local
 │
 ├── schemas/                            # Official schema definitions
 │   ├── registry.yaml                   # Master index (see below)
 │   ├── rfq_electric_utility.yaml
-│   ├── change_order.yaml               # (future)
-│   └── ...
+│   └── ...                             # (future: change_order, etc.)
 │
-├── templates/                          # Programmatic doc templates
-│   ├── rfq_electric_utility.py         # python-docx builder for RFQ
-│   └── ...
-│
-├── workbook/                           # Distributable workbook
-│   ├── DocGen.xlsx                     # The thin-shell workbook
-│   ├── scripts.py                      # xlwings Lite scripts (pasted into add-in)
-│   └── requirements.txt                # Pyodide package list
+├── workbook/                           # Thin-shell workbook bootstrap
+│   ├── loader.py                       # Stable loader (paste into xlwings Lite)
+│   ├── runner.py                       # Business logic (fetched at runtime)
+│   ├── scripts.py                      # Self-contained alternative
+│   └── README.md                       # Setup instructions
 │
 ├── docs/
 │   ├── CONTRIBUTING.md                 # How to contribute schemas/templates
 │   ├── SCHEMA_AUTHORING.md             # How to write a new schema
-│   ├── TEMPLATE_AUTHORING.md           # How to write a doc template
 │   └── USER_GUIDE.md                   # End-user documentation
 │
-└── tests/                              # Schema + engine tests
+└── tests/                              # Schema + engine tests (64 tests)
+    ├── conftest.py                     # Shared fixtures
     ├── test_schema_loader.py
     ├── test_data_exchange.py
-    └── test_doc_generator.py
+    ├── test_github_loader.py
+    ├── test_excel_builder.py
+    ├── test_doc_generator.py
+    ├── test_file_bridge.py
+    └── test_validation_ux.py
 ```
 
 ### Schema Registry (`schemas/registry.yaml`)
@@ -385,82 +385,59 @@ This is safe in our context because:
 
 ---
 
-## Workbook Design (Thin Shell)
+## Workbook Design (Loader / Runner)
 
-The workbook itself contains minimal logic — just enough to bootstrap
-the system by fetching everything else from GitHub.
+The workbook uses a two-layer architecture: a **stable loader** pasted
+into xlwings Lite once, and a **runner** fetched from GitHub at runtime.
 
 ### What lives IN the workbook:
 
-- **xlwings Lite script**: ~50 lines of bootstrap code that fetches the
-  engine from GitHub and wires up the `@script` buttons
-- **Control sheet**: Document type dropdown, config cells (GitHub URL,
-  local path), action buttons, status display
-- **requirements.txt**: Package list for Pyodide
+- **loader.py**: ~120 lines of stable bootstrap code pasted into the
+  xlwings Lite code editor. Fetches the runner from GitHub and exposes
+  `@xw.script` entry points. Rarely needs updating.
+- **requirements.txt**: `pyyaml`, `python-docx`
 
 ### What lives OUTSIDE the workbook (fetched at runtime):
 
+- **runner.py** — All business logic (fetched by the loader)
 - Engine modules (schema_loader, data_exchange, doc_generator, etc.)
 - Schema definitions (YAML files)
-- Document templates (Python modules)
 - Registry (master index)
 
-### Bootstrap Script (in xlwings Lite)
+### Architecture
 
-```python
-import xlwings as xw
-from xlwings import script
-import requests
-import yaml
-
-GITHUB_BASE = "https://raw.githubusercontent.com/ccirone2/docx_builder/main"
-
-
-def _fetch(path):
-    """Fetch a file from GitHub with caching."""
-    if not hasattr(_fetch, "_cache"):
-        _fetch._cache = {}
-    url = f"{GITHUB_BASE}/{path}"
-    if url not in _fetch._cache:
-        _fetch._cache[url] = requests.get(url).text
-    return _fetch._cache[url]
-
-
-def _load_engine():
-    """Fetch and execute engine modules from GitHub."""
-    modules = {}
-    for name in ["config", "schema_loader", "data_exchange",
-                  "doc_generator", "excel_builder", "file_bridge"]:
-        source = _fetch(f"engine/{name}.py")
-        ns = {"__name__": f"engine.{name}"}
-        exec(source, ns)
-        modules[name] = ns
-    return modules
-
-
-@script(button="[btn_init]Control!B5")
-def initialize(book: xw.Book):
-    """Fetch registry, populate schema dropdown, build sheets."""
-    control = book.sheets["Control"]
-    control["D3"].value = "Loading..."
-
-    # Fetch registry
-    registry_text = _fetch("schemas/registry.yaml")
-    registry = yaml.safe_load(registry_text)
-
-    # Populate dropdown with schema names
-    schema_names = [s["name"] for s in registry["schemas"]]
-    # ... write to dropdown range, build sheets
-
-    control["D3"].value = f"Ready — {len(schema_names)} document types loaded"
-
-
-@script(button="[btn_generate]Control!B7")
-def generate(book: xw.Book):
-    """Read data, validate, generate .docx, trigger download."""
-    engine = _load_engine()
-    # ... use engine modules to build document
 ```
+loader.py (pasted once into xlwings Lite)
+  └── fetches runner.py from GitHub
+        └── fetches engine/*.py from GitHub
+              └── fetches schemas/*.yaml from GitHub
+```
+
+The loader defines thin `@xw.script` entry points that delegate to the
+runner. The runner handles engine loading with a dependency graph,
+Control sheet creation via `init_workbook()`, and all data operations.
+
+### One-Click Setup
+
+Users paste `loader.py` and click **Init Workbook**. The runner's
+`init_workbook()` function:
+1. Fetches the schema registry from GitHub
+2. Creates the Control sheet with labels, buttons, and config cells
+3. Builds data entry sheets for the default document type
+
+No manual sheet creation required.
+
+### Updating
+
+- **Runner/engine changes**: Automatic — reopen workbook or click
+  "Reload Scripts" to re-fetch
+- **New script buttons**: Only needed when adding new `@xw.script`
+  entry points to loader.py (rare)
+
+### Alternative: Self-Contained Script
+
+`scripts.py` bundles all logic inline for cases where remote fetching
+is not desired. It must be re-pasted when code is updated.
 
 ---
 
@@ -506,13 +483,13 @@ Control Sheet Layout:
 |-------|----------------------------|------------------------------------------------|
 | ✅ 1  | Schema system              | YAML format + loader + validator + compound     |
 | ✅ 1b | Data exchange              | YAML import/export + LLM prompt + redaction     |
-| 🔲 2  | GitHub loader              | Fetch registry, schemas, templates from GitHub  |
-| 🔲 3  | Excel builder              | Auto-generate data entry sheets from schema     |
-| 🔲 4  | Document builder           | python-docx programmatic templates              |
-| 🔲 5  | Browser download bridge    | Pyodide → JS file download                      |
-| 🔲 6  | Workbook bootstrap         | Thin-shell workbook + @script wiring            |
-| 🔲 7  | Local customization        | File picker, paste, fork URL support            |
-| 🔲 8  | Validation UX              | In-sheet error display + status messages         |
+| ✅ 2  | GitHub loader              | Fetch registry, schemas from GitHub + caching   |
+| ✅ 3  | Excel builder              | Auto-generate data entry sheets from schema     |
+| ✅ 4  | Document builder           | python-docx programmatic templates              |
+| ✅ 5  | Browser download bridge    | Pyodide → JS file download                      |
+| ✅ 6  | Workbook bootstrap         | Loader/runner architecture + @script wiring     |
+| ✅ 7  | Local customization        | File picker, paste, fork URL support            |
+| ✅ 8  | Validation UX              | Color-coded validation reports                   |
 | 🔲 9  | Contribution tooling       | Schema/template validation CLI, PR template      |
 | 🔲 10 | Template system v2         | docxtpl + hosted .docx templates (optional)      |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Before ending ANY session, always:
 - Use dataclasses, not raw dicts, for structured data
 - Docstrings on all public functions (Google style)
 - Keep modules under 400 lines; split if larger
-- No `print()` in library code — use return values; `print()` only in CLI blocks
+- No `print()` in library code — use `engine.log` helpers; `print()` only in CLI blocks
 
 ## Git Conventions
 - Branch naming: `feature/xxx`, `fix/xxx`, `docs/xxx`
@@ -49,7 +49,14 @@ Before ending ANY session, always:
 - `engine/data_exchange.py` — YAML import/export, LLM prompts, redaction
 - `engine/github_loader.py` — Fetch schemas/templates from GitHub + local
 - `engine/config.py` — Pyodide-aware settings
+- `engine/log.py` — Timestamped logging (DEBUG/INFO/WARN/ERROR)
+- `engine/doc_generator.py` — python-docx document generation
+- `engine/excel_builder.py` — Schema-driven Excel sheet planning
 - `engine/file_bridge.py` — Pyodide → browser download via JS bridge
+- `engine/validation_ux.py` — Color-coded validation reports
+- `engine/template_registry.py` — Schema ↔ template mapping
+- `workbook/loader.py` — Stable xlwings Lite bootstrap (paste once)
+- `workbook/runner.py` — Business logic (fetched at runtime from GitHub)
 - `schemas/registry.yaml` — Master index of document types
 - `schemas/rfq_electric_utility.yaml` — RFQ schema (36 fields, 9 groups)
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ GitHub (schemas, templates, engine code)
 
 1. Install the [xlwings Lite](https://www.xlwings.org/lite) add-in from the Office add-in store
 2. Open a blank workbook
-3. Create a "Control" sheet following the layout in the [workbook README](workbook/README.md)
-4. Paste the bootstrap script into the xlwings Lite code editor
-5. Click **Initialize** to load available document types
+3. Paste the contents of [`workbook/loader.py`](workbook/loader.py) into the xlwings Lite code editor
+4. Add `pyyaml` and `python-docx` to the xlwings Lite requirements
+5. Click **Init Workbook** — the Control sheet and data entry sheets are created automatically
+
+See the [workbook README](workbook/README.md) for detailed setup instructions.
 
 ## Quickstart (Contributors)
 

--- a/docs/BOOTSTRAP_PROMPT.md
+++ b/docs/BOOTSTRAP_PROMPT.md
@@ -1,3 +1,7 @@
+> **Historical context:** This document was the original bootstrap prompt used
+> to build the project from scratch. Phases A–H are now complete. See
+> `docs/PLAN.md` for current status and `docs/DEVLOG.md` for session history.
+
 You are completing the build of **docx_builder** — an open-source, template-driven document generator for the electric utility industry. Excel (xlwings Lite / Pyodide) handles data entry, Python generates Word .docx files. Everything runs in-browser via WebAssembly — zero Python install.
 
 ## What already exists in the repo

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -85,3 +85,64 @@ entire engine, workbook integration, and documentation in one session.
 - tests/ (7 test files, 56 tests total)
 - pyproject.toml, README.md, LICENSE, .gitignore
 - docs/CONTRIBUTING.md, docs/SCHEMA_AUTHORING.md, docs/USER_GUIDE.md
+
+## 2026-02-28 — Easy Workbook Init (PR #4)
+
+Major refactor of the workbook bootstrap system. Replaced the
+monolithic scripts.py with a two-layer loader/runner architecture.
+
+### Loader/Runner Architecture
+- **loader.py**: Stable ~120-line bootstrap pasted into xlwings Lite.
+  Defines `@xw.script` entry points that delegate to the runner.
+  Never needs updating unless new buttons are added.
+- **runner.py**: ~500-line business logic module fetched from GitHub
+  at runtime. All updates take effect automatically.
+- **init_workbook()**: One-click setup — creates Control sheet with
+  labels, formatting, config cells, and builds data entry sheets.
+  No manual sheet creation required.
+
+### xlwings Lite Compatibility Fixes
+- Removed `from __future__ import annotations` (breaks Pyodide)
+- Removed all merge operations (Office.js incompatibility)
+- Removed autofit/column_width code (not supported in Lite)
+- Wrapped formatting in try/except for graceful degradation
+- Used values-only mode for cell writes
+
+### Logging & Status
+- Added `engine/log.py` with timestamped DEBUG/INFO/WARN/ERROR
+- All status output via print() to xlwings task pane
+- Improved error reporting with exception type and step progress
+
+### Other Changes
+- Custom GitHub URL read from Control!D12
+- 404 handling in loader and github_loader
+- BRANCH variable for non-main branch support
+- scripts.py preserved as self-contained alternative
+- excel_builder.py expanded with control sheet planning (+8 tests)
+
+**Files created:** workbook/loader.py, workbook/runner.py, engine/log.py
+**Files modified:** engine/excel_builder.py, engine/data_exchange.py,
+  engine/doc_generator.py, engine/file_bridge.py, engine/github_loader.py,
+  engine/schema_loader.py, workbook/scripts.py, workbook/README.md,
+  tests/test_excel_builder.py
+
+**Test count:** 64 tests across 7 test files (up from 56)
+
+## 2026-03-02 — Documentation Audit
+
+Verified all documentation against current codebase and PRs. Fixed:
+
+- **ARCHITECTURE.md**: Updated repo structure (added loader.py,
+  runner.py, log.py, validation_ux.py; removed references to
+  nonexistent templates/ directory, DocGen.xlsx, and
+  TEMPLATE_AUTHORING.md). Updated build phases table (phases 2–8
+  marked complete). Replaced bootstrap script section with
+  loader/runner architecture description.
+- **PLAN.md**: Updated test count from 56 to 64.
+- **README.md**: Updated user quickstart to reference loader.py
+  and init_workbook() instead of manual Control sheet creation.
+- **CLAUDE.md**: Added engine/log.py and all missing modules to
+  architecture quick reference. Updated print() convention to
+  reference engine.log helpers.
+- **BOOTSTRAP_PROMPT.md**: Added historical context note.
+- **DEVLOG.md**: Added entries for PR #4 changes and this audit.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -19,11 +19,11 @@
 | E | Browser download bridge | ✅ Done | generate_and_download pipeline |
 | F | Workbook bootstrap | ✅ Done | xlwings Lite scripts |
 | G | Local customization & validation | ✅ Done | Custom schemas, validation UX |
-| H | Finalization | ✅ Done | 56 tests, lint clean, docs updated |
+| H | Finalization | ✅ Done | 64 tests, lint clean, docs updated |
 
 ### Test Summary
 
-- 56 tests across 7 test files
+- 64 tests across 7 test files (+ conftest.py)
 - All passing, lint clean
 - Coverage: schema_loader, data_exchange, github_loader, excel_builder, doc_generator, file_bridge, validation_ux
 


### PR DESCRIPTION
## Summary

This PR refactors the workbook bootstrap system from a monolithic approach to a two-layer **loader/runner architecture**, improving maintainability and update frequency. It also audits and updates all documentation to reflect the current codebase state.

## Key Changes

### Workbook Architecture (Loader/Runner)
- **loader.py** (~120 lines): Stable bootstrap code pasted once into xlwings Lite. Defines `@xw.script` entry points and fetches the runner from GitHub. Rarely needs updating.
- **runner.py** (~500 lines): Business logic module fetched at runtime from GitHub. All updates take effect automatically without re-pasting.
- **init_workbook()**: One-click setup function that creates the Control sheet with labels, formatting, config cells, and builds data entry sheets automatically. Eliminates manual sheet creation.

### xlwings Lite Compatibility Fixes
- Removed `from __future__ import annotations` (breaks Pyodide)
- Removed merge operations (Office.js incompatibility)
- Removed autofit/column_width code (unsupported in Lite)
- Wrapped formatting in try/except for graceful degradation
- Used values-only mode for cell writes

### Logging & Status Reporting
- Added `engine/log.py` with timestamped DEBUG/INFO/WARN/ERROR helpers
- All status output via print() to xlwings task pane
- Improved error reporting with exception type and step progress

### Documentation Audit
- **ARCHITECTURE.md**: Updated repo structure diagram and build phases table (phases 2–8 now marked complete). Replaced bootstrap script section with loader/runner architecture description.
- **README.md**: Updated user quickstart to reference `loader.py` and `init_workbook()` instead of manual Control sheet creation.
- **CLAUDE.md**: Added missing modules to architecture quick reference. Updated logging convention to reference `engine.log` helpers.
- **BOOTSTRAP_PROMPT.md**: Added historical context note.
- **DEVLOG.md**: Added entries for PR #4 changes and documentation audit.
- **PLAN.md**: Updated test count from 56 to 64.

### Other Changes
- Custom GitHub URL read from Control!D12
- 404 handling in loader and github_loader
- BRANCH variable for non-main branch support
- scripts.py preserved as self-contained alternative
- excel_builder.py expanded with control sheet planning (+8 tests)

## Test Coverage

- 64 tests across 7 test files (up from 56)
- All passing, lint clean
- Coverage: schema_loader, data_exchange, github_loader, excel_builder, doc_generator, file_bridge, validation_ux

https://claude.ai/code/session_01YTTcuVToJWS15jJ7z3neWR