### PR TITLE
feat: show validation error details in output pane

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -409,3 +409,28 @@ across the remaining docs.
 **Files deleted:** docs/plan.md, docs/BOOTSTRAP_PROMPT.md, docs/DEV_INFRASTRUCTURE.md
 **Files modified:** docs/CONTRIBUTING.md, docs/USER_GUIDE.md,
   docs/SCHEMA_AUTHORING.md, docs/PLAN.md, CLAUDE.md
+
+## 2026-03-02 — Issue #10: Validation error detail in output pane
+
+Implemented [#10](https://github.com/ccirone2/docx_builder/issues/10).
+When `validate_data` or `generate_document` fails validation, the output
+pane now prints each error and warning on its own line in a compact format:
+
+```
+[17:45:50] ERROR  Validation failed: 17 errors
+[17:45:50] ERROR    - Project Title: missing
+[17:45:50] ERROR    - Utility Name: missing
+```
+
+### Changes
+- `workbook/runner.py`: Added `_format_validation_line()` to condense raw
+  error strings (e.g. "Missing required field: Label (key)") into compact
+  one-liners ("Label: missing"). Added `_report_validation()` to print
+  summary + per-item detail. Wired into both `validate_data()` and
+  `generate_document()`.
+- `tests/test_runner.py`: 11 new tests covering `_format_validation_line`
+  (7 cases) and `_report_validation` (4 cases).
+
+**Files created:** tests/test_runner.py
+**Files modified:** workbook/runner.py, docs/DEVLOG.md
+**Test count:** 160 tests across 13 files (up from 149)

--- a/tests/test_excel_builder.py
+++ b/tests/test_excel_builder.py
@@ -1,13 +1,13 @@
 """Tests for engine/excel_plan.py and engine/excel_control.py — pure logic layer."""
 from __future__ import annotations
 
+from engine.excel_control import plan_control_sheet
 from engine.excel_plan import (
     CellInstruction,
     plan_group_layout,
     plan_sheets,
     plan_table_layout,
 )
-from engine.excel_control import plan_control_sheet
 from engine.schema_loader import Schema
 
 

--- a/tests/test_local_runner.py
+++ b/tests/test_local_runner.py
@@ -1,8 +1,6 @@
 """Tests for dev.local_runner — local pipeline orchestration."""
 from __future__ import annotations
 
-import pytest
-
 from dev.local_runner import (
     export_yaml,
     fill_data,
@@ -13,7 +11,6 @@ from dev.local_runner import (
 )
 from dev.mock_book import MockBook
 from engine.schema_loader import Schema
-
 
 # ---------------------------------------------------------------------------
 # init_workbook

--- a/tests/test_mock_book.py
+++ b/tests/test_mock_book.py
@@ -7,7 +7,6 @@ import pytest
 
 from dev.mock_book import MockBook, MockCell, MockSheet, _a1_to_rowcol
 
-
 # ---------------------------------------------------------------------------
 # A1 notation parsing
 # ---------------------------------------------------------------------------

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,108 @@
+"""Tests for workbook/runner.py — validation reporting helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field as dc_field
+
+from workbook.runner import _format_validation_line, _report_validation
+
+
+# Minimal stand-in for ValidationResult so we don't import schema_loader twice
+@dataclass
+class _FakeValidation:
+    valid: bool = True
+    errors: list[str] = dc_field(default_factory=list)
+    warnings: list[str] = dc_field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# _format_validation_line
+# ---------------------------------------------------------------------------
+
+
+class TestFormatValidationLine:
+    def test_missing_required_field(self):
+        msg = "Missing required field: Project Title (project_title)"
+        assert _format_validation_line(msg) == "  - Project Title: missing"
+
+    def test_missing_required_sub_field(self):
+        msg = "Missing required sub-field: Address → City (address.city)"
+        assert _format_validation_line(msg) == "  - Address → City: missing"
+
+    def test_date_format_error(self):
+        msg = "RFQ Issue Date: Expected date format YYYY-MM-DD, got '03/01/2026'"
+        result = _format_validation_line(msg)
+        assert result.startswith("  - RFQ Issue Date: ")
+        assert "YYYY-MM-DD" in result
+
+    def test_invalid_choice_warning(self):
+        msg = "Work Category: 'Invalid' not in expected choices"
+        result = _format_validation_line(msg)
+        assert result == "  - Work Category: 'Invalid' not in expected choices"
+
+    def test_number_format_error(self):
+        msg = "Quantity: Expected a number, got 'abc'"
+        result = _format_validation_line(msg)
+        assert result.startswith("  - Quantity: ")
+
+    def test_long_detail_truncated(self):
+        detail = "x" * 100
+        msg = f"Field: {detail}"
+        result = _format_validation_line(msg)
+        assert len(result) < len(msg)
+        assert result.endswith("...")
+
+    def test_fallback_no_colon(self):
+        msg = "Something went wrong"
+        result = _format_validation_line(msg)
+        assert result == "  - Something went wrong"
+
+
+# ---------------------------------------------------------------------------
+# _report_validation
+# ---------------------------------------------------------------------------
+
+
+class TestReportValidation:
+    def test_errors_printed(self, capsys):
+        validation = _FakeValidation(
+            valid=False,
+            errors=[
+                "Missing required field: Project Title (project_title)",
+                "Missing required field: Utility Name (issuer_name)",
+            ],
+        )
+        _report_validation(None, validation)
+        captured = capsys.readouterr().out
+        assert "Validation failed: 2 errors" in captured
+        assert "Project Title: missing" in captured
+        assert "Utility Name: missing" in captured
+
+    def test_warnings_printed(self, capsys):
+        validation = _FakeValidation(
+            valid=True,
+            warnings=["Work Category: 'Invalid' not in expected choices"],
+        )
+        _report_validation(None, validation)
+        captured = capsys.readouterr().out
+        assert "Validation warnings: 1" in captured
+        assert "Work Category" in captured
+
+    def test_no_output_when_valid_no_warnings(self, capsys):
+        validation = _FakeValidation(valid=True)
+        _report_validation(None, validation)
+        captured = capsys.readouterr().out
+        assert captured == ""
+
+    def test_errors_and_warnings_together(self, capsys):
+        validation = _FakeValidation(
+            valid=False,
+            errors=["Missing required field: Title (title)"],
+            warnings=["Category: 'Bad' not in expected choices"],
+        )
+        _report_validation(None, validation)
+        captured = capsys.readouterr().out
+        assert "Validation failed: 1 errors" in captured
+        assert "Title: missing" in captured
+        assert "Validation warnings: 1" in captured
+        assert "Category" in captured

--- a/workbook/runner.py
+++ b/workbook/runner.py
@@ -372,6 +372,54 @@ def _report_error(book: Any, exc: Exception) -> None:
     _set_status(book, f"Error [{type(exc).__name__}]: {msg}")
 
 
+def _format_validation_line(message: str) -> str:
+    """Convert a raw validation error/warning into a compact one-liner.
+
+    Input formats from schema_loader:
+        "Missing required field: Project Title (project_title)"
+        "Missing required sub-field: Address → City (address.city)"
+        "Field Label: Expected date format YYYY-MM-DD, got 'val'"
+
+    Returns:
+        Compact string like "Project Title: missing" or
+        "Field Label: invalid date format".
+    """
+    # "Missing required field: Label (key)" or "Missing required sub-field: ..."
+    if message.startswith("Missing required"):
+        # Extract the label between the first ": " and the last " ("
+        colon_idx = message.index(": ") + 2
+        paren_idx = message.rfind(" (")
+        label = message[colon_idx:paren_idx] if paren_idx > colon_idx else message[colon_idx:]
+        return f"  - {label}: missing"
+
+    # "Label: detail message" — keep label, shorten detail
+    if ": " in message:
+        label, detail = message.split(": ", 1)
+        # Truncate long detail messages
+        if len(detail) > 60:
+            detail = detail[:57] + "..."
+        return f"  - {label}: {detail}"
+
+    return f"  - {message}"
+
+
+def _report_validation(book: Any, validation: Any) -> None:
+    """Print a compact summary + per-item detail for validation results.
+
+    Args:
+        book: The xlwings Book object (passed to _set_status).
+        validation: A ValidationResult with .errors and .warnings lists.
+    """
+    if validation.errors:
+        _set_status(book, f"Validation failed: {len(validation.errors)} errors")
+        for err in validation.errors:
+            _set_status(book, _format_validation_line(err))
+    if validation.warnings:
+        _set_status(book, f"Validation warnings: {len(validation.warnings)}")
+        for warn in validation.warnings:
+            _set_status(book, f"Warning: {_format_validation_line(warn)}")
+
+
 def initialize_sheets(book: Any) -> None:
     """Fetch registry, populate dropdown, build data entry sheets."""
     _set_status(book, "initialize_sheets triggered")
@@ -420,7 +468,7 @@ def generate_document(book: Any) -> None:
         loader = _load_module("schema_loader")
         validation = loader["validate_data"](schema, data)
         if not validation.valid:
-            _set_status(book, f"Validation failed: {len(validation.errors)} errors")
+            _report_validation(book, validation)
             return
         doc_gen = _load_module("doc_generator")
         doc = doc_gen["generate_document"](schema, data)
@@ -449,8 +497,10 @@ def validate_data(book: Any) -> None:
             if validation.warnings:
                 msg += f" ({len(validation.warnings)} warnings)"
             _set_status(book, msg)
+            if validation.warnings:
+                _report_validation(book, validation)
         else:
-            _set_status(book, f"Validation failed: {len(validation.errors)} errors")
+            _report_validation(book, validation)
     except Exception as e:
         _report_error(book, e)
 


### PR DESCRIPTION
## Summary
- Adds `_format_validation_line()` and `_report_validation()` helpers to `workbook/runner.py` that print compact per-error/warning lines to the output pane instead of just an error count
- Wires the new helpers into both `validate_data()` and `generate_document()` 
- 11 new tests in `tests/test_runner.py` covering formatting and output behavior

Closes #10

## Before
```
[17:45:50] ERROR  Validation failed: 17 errors
```

## After
```
[17:45:50] ERROR  Validation failed: 17 errors
[17:45:50] ERROR    - Project Title: missing
[17:45:50] ERROR    - Utility Name: missing
[17:45:50] ERROR    - RFQ Issue Date: missing
```

## Test plan
- [x] All 160 tests pass (`PYTHONPATH=. python -m pytest tests/ -v`)
- [x] Lint clean on changed files (`ruff check workbook/runner.py tests/test_runner.py`)
- [ ] Manual verification in xlwings Lite: run validate_data with empty fields and confirm per-field errors appear in output pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)