### PR TITLE
docs: document develop branch workflow

### DIFF
--- a/.claude/agents/documenter.md
+++ b/.claude/agents/documenter.md
@@ -1,9 +1,9 @@
 ---
 name: documenter
 description: >
-  Updates project documentation, dev logs, decision records, and
-  plans. Use at the end of sessions or after significant changes
-  to keep all documentation current.
+  Updates project documentation, dev logs, decision records, and plans.
+  Use at the end of sessions or after significant changes to keep all
+  documentation current.
 tools: Read, Write, Edit, Glob, Grep, Bash(git diff*), Bash(git log*)
 model: sonnet
 ---
@@ -11,6 +11,16 @@ model: sonnet
 You are a technical writer responsible for keeping this project's
 documentation current and useful for the next developer (human or AI)
 who picks up the work.
+
+## Branching Model
+- `main` = stable releases only. `develop` = integration branch.
+- All feature branches branch from `develop` and PR back into `develop`.
+- When referencing diffs, use `develop` as the base (not `main`).
+
+## Worktree Awareness
+You may be running in an isolated git worktree. If so, your working
+directory is a temporary copy. Commit and push your changes — the
+worktree is cleaned up automatically.
 
 ## Your Files
 - `docs/DEVLOG.md` — Append-only development log

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -10,6 +10,16 @@ model: sonnet
 
 You are a senior software architect and project planner.
 
+## Branching Model
+- `main` = stable releases only. `develop` = integration branch.
+- All feature branches branch from `develop` and PR back into `develop`.
+- When planning tasks, note that branches should be created from `develop`.
+
+## Worktree Awareness
+You may be running in an isolated git worktree. If so, your working
+directory is a temporary copy of the repo. This is normal — read files
+and create plans as usual.
+
 ## Your Role
 - Break complex features into discrete, testable tasks
 - Identify dependencies and optimal implementation order

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -11,6 +11,10 @@ model: sonnet
 You are a meticulous code reviewer for a Python project that
 must run in Pyodide (browser-based WebAssembly).
 
+## Branching Model
+- `develop` is the integration branch. Diff against `develop` (not `main`).
+- You may be running in a worktree — this is normal, review as usual.
+
 ## Review Checklist
 - [ ] Type hints on all function signatures
 - [ ] Google-style docstrings on public functions

--- a/.claude/agents/schema-author.md
+++ b/.claude/agents/schema-author.md
@@ -8,7 +8,14 @@ tools: Read, Write, Edit, Glob, Grep, Bash(python*)
 model: sonnet
 ---
 
-You are an expert in the docx_builder schema system. You know:
+You are an expert in the docx_builder schema system.
+
+## Branching Model
+- `develop` is the integration branch. Branch from `develop` for all work.
+- You may be running in an isolated worktree. Commit and push your
+  changes — the worktree is cleaned up automatically.
+
+You know:
 
 ## Schema Structure
 - Three-tier fields: core (required), optional, flexible

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -2,13 +2,22 @@
 
 1. Read `docs/PLAN.md` and find the next uncompleted task
 2. Read the corresponding GitHub issue for full context
-3. Create a feature branch: `git checkout -b feature/ISSUE-NUMBER-short-description`
-4. Implement the task, following conventions in CLAUDE.md
-5. Write or update tests for the changed code
-6. Run tests: `PYTHONPATH=. python -m pytest tests/ -v`
-7. Run lint: `ruff check engine/ --fix && ruff format engine/`
-8. Update the task status in `docs/PLAN.md` to ✅
-9. Commit with conventional format referencing the issue
-10. Update `docs/DEVLOG.md` with what was done
+3. Ensure you are on `develop`: `git checkout develop && git pull origin develop`
+4. Create a feature branch: `git checkout -b feature/ISSUE-NUMBER-short-description`
+5. Implement the task, following conventions in CLAUDE.md
+6. Write or update tests for the changed code
+7. Run tests: `PYTHONPATH=. python -m pytest tests/ -v`
+8. Run lint: `ruff check engine/ dev/ --fix && ruff format engine/ dev/`
+9. Update the task status in `docs/PLAN.md` to ✅
+10. Commit with conventional format referencing the issue
+11. Push and open a PR targeting `develop`: `gh pr create --base develop`
+12. Update `docs/DEVLOG.md` with what was done
+
+**Branching:** All feature branches start from `develop`. PRs target `develop`.
+Only `develop` → `main` merges happen for stable releases.
+
+**Worktree:** If running in a worktree (isolated agent), you are in a
+temporary copy of the repo. Create your branch, commit, and push — the
+worktree will be cleaned up automatically.
 
 If $ARGUMENTS is provided, implement that specific task/issue instead.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -2,7 +2,7 @@
 
 Review the recent changes for quality and correctness.
 
-1. Run `git diff main --stat` to see what changed
+1. Run `git diff develop --stat` to see what changed
 2. For each modified file, check:
    - Type hints on all function signatures
    - Docstrings on all public functions

--- a/.claude/commands/wrapup.md
+++ b/.claude/commands/wrapup.md
@@ -3,7 +3,7 @@
 Perform all end-of-session housekeeping:
 
 1. Run tests and report results: `PYTHONPATH=. python -m pytest tests/ -v`
-2. Run lint: `ruff check engine/`
+2. Run lint: `ruff check engine/ dev/`
 3. Append a dated entry to `docs/DEVLOG.md` with:
    - Date and session summary
    - What was accomplished (files changed, features added)
@@ -16,4 +16,7 @@ Perform all end-of-session housekeeping:
    - Update the "Current Status" section
 5. If architecture decisions were made, append to `docs/DECISIONS.md`
 6. Verify all changes are committed
-7. Print a final status summary
+7. If on a feature branch, push and open a PR targeting `develop`
+8. Print a final status summary
+
+**Branching:** PRs target `develop`. Only merge `develop` → `main` for stable releases.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '📋 Current plan:' && head -50 docs/PLAN.md 2>/dev/null || echo 'No plan yet.' && echo '' && echo '📝 Recent dev log:' && tail -30 docs/DEVLOG.md 2>/dev/null || echo 'No log yet.' && echo '' && echo '🔀 Git status:' && git status --short && echo '' && echo '📌 Open issues:' && gh issue list --limit 5 2>/dev/null || echo 'gh CLI not configured'",
+            "command": "echo '📋 Current plan:' && head -50 docs/PLAN.md 2>/dev/null || echo 'No plan yet.' && echo '' && echo '📝 Recent dev log:' && tail -30 docs/DEVLOG.md 2>/dev/null || echo 'No log yet.' && echo '' && echo '🔀 Git status:' && echo \"Branch: $(git branch --show-current) (default: develop)\" && git status --short && echo '' && echo '📌 Open issues:' && gh issue list --limit 5 2>/dev/null || echo 'gh CLI not configured'",
             "timeout": 10
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,13 @@ Before ending ANY session, always:
 - No `print()` in library code — use `engine.log` helpers; `print()` only in CLI blocks
 
 ## Git Conventions
-- Branch naming: `feature/xxx`, `fix/xxx`, `docs/xxx`
+- **Branching model:** `main` (stable releases) ← `develop` (integration) ← feature branches
+- `develop` is the default branch on GitHub; all PRs target `develop`
+- Only merge `develop` → `main` when a version is stable (tag with `vX.Y.Z`)
+- Branch naming: `feature/xxx`, `fix/xxx`, `docs/xxx` (branch from `develop`)
 - Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
 - Always reference GitHub issue: `feat: add excel builder (#12)`
-- Never commit directly to `main` — always use branches + PRs
+- Never commit directly to `main` or `develop` — always use branches + PRs
 - Squash merge PRs to keep history clean
 
 ## Architecture Quick Reference


### PR DESCRIPTION
## Summary
- Updates CLAUDE.md Git Conventions to reflect the new branching model
- `develop` is now the default/integration branch; `main` is for stable releases only
- All feature branches branch from and PR into `develop`

## Test plan
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)